### PR TITLE
Use AwsCFlags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required (VERSION 3.1)
 project (aws-checksums C)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/lib/cmake")
+include(AwsCFlags)
+
 file(GLOB AWS_CHECKSUMS_HEADERS
      "include/aws/checksums/*.h"
 )
@@ -58,9 +61,8 @@ else()
 endif()
 
 add_library(aws-checksums ${LIBTYPE} ${CHECKSUMS_HEADERS} ${CHECKSUMS_SRC})
-set_target_properties(aws-checksums PROPERTIES LINKER_LANGUAGE C)
+aws_set_common_properties(aws-checksums NO_PEDANTIC NO_WEXTRA)
 set(CMAKE_C_FLAGS_DEBUGOPT "")
-set_property(TARGET aws-checksums PROPERTY C_STANDARD 99)
 
 if(BUILD_SHARED_LIBS AND WIN32)
     target_compile_definitions(aws-checksums PRIVATE "-DAWS_CHECKSUMS_EXPORTS")    


### PR DESCRIPTION
Hi, I am trying to link libaws-checksums.a to a shared library. I get the following error:
```
/usr/bin/ld: /work/utils/install/lib/libaws-checksums.a(crc_sw.c.o): relocation R_X86_64_PC32 against symbol `CRC32_TABLE' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
```
Minimal example to reproduce:
I followed the first three steps from https://github.com/aws/aws-sdk-cpp/issues/1020#issuecomment-441843581 but for aws-c-common and aws-checksum I configured cmake with
```
cmake .. -DCMAKE_INSTALL_PREFIX=/work/utils/install -DBUILD_SHARED_LIBS=OFF
```
For aws-c-event-stream I built shared libraries with:
```
cmake .. -DCMAKE_INSTALL_PREFIX=/work/utils/aws_deps -DBUILD_SHARED_LIBS=ON
```
My solution was to change the ```CMakeLists.txt``` of aws-checksums to also use ```AwsCFlags```. I created a small pull request for that, but it adds a dependency to aws-c-common.