### PR TITLE
Add return in aws_checksums_crc32c_hw()

### DIFF
--- a/source/arm/crc32c_arm.c
+++ b/source/arm/crc32c_arm.c
@@ -19,7 +19,7 @@
 #    include <aws/checksums/private/crc_priv.h>
 
 uint32_t aws_checksums_crc32c_hw(const uint8_t *data, int length, uint32_t previousCrc32) {
-    aws_checksums_crc32c_sw(data, length, previousCrc32);
+    return aws_checksums_crc32c_sw(data, length, previousCrc32);
 }
 
 #endif


### PR DESCRIPTION
*Issue*
aws_checksums_crc32c_hw() is missing return in crc32c_arm.c

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
