### PR TITLE
[Windows][Clang] Fix ODR aws_checksums_do_cpu_id

### DIFF
--- a/source/intel/cpuid.c
+++ b/source/intel/cpuid.c
@@ -16,8 +16,9 @@
 #include <aws/checksums/private/cpuid.h>
 #include <stdint.h>
 
-#if defined(__x86_64__) &&                                                                                             \
-    (defined(__clang__) || !((defined(__GNUC__)) && ((__GNUC__ == 4 && __GNUC_MINOR__ < 4) || defined(DEBUG_BUILD))))
+#if defined(__x86_64__) \
+  && (( defined(__clang__) && !defined(_M_X64) && !defined(_M_IX86) ) \
+    || !( defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ < 4) || defined(DEBUG_BUILD)) ))
 
 static int32_t s_cpuid_output = 0;
 static int s_cpuid_ran = 0;
@@ -39,5 +40,6 @@ int aws_checksums_do_cpu_id(int32_t *cpuid) {
     return 1;
 }
 
-#endif /* defined(__x86_64__) && (defined(__clang__) || !((defined(__GNUC__)) && ((__GNUC__ == 4 && __GNUC_MINOR__ <   \
-          4) || defined(DEBUG_BUILD)))) */
+#endif /* defined(__x86_64__) \
+  && (( defined(__clang__) && !defined(_M_X64) && !defined(_M_IX86) ) \
+    || !( defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ < 4) || defined(DEBUG_BUILD)) )) */


### PR DESCRIPTION
*Issue #, if available:*

Windows build with Clang (lld-link) .

  C:/local/llvm/bin/lld-link.exe @bazel-out/x64_windows-dbg/bin/tensorflow/tensorflow_framework.dll-2.params
Execution platform: //:x64_windows-clang-cl
lld-link: error: duplicate symbol: aws_checksums_do_cpu_id
>>> defined at C:\users\sp_farm\_bazel_sp_farm\btxde6oq\execroot\org_tensorflow\external\aws-checksums\source\visualc\visualc_cpuid.c:29
>>>            aws-checksums.lib(visualc_cpuid.obj)
>>> defined at aws-checksums.lib(cpuid.obj)

*Description of changes:*

Keep only one `aws_checksums_do_cpu_id` definition (visualc one to be closer to MSVC behavior)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
