### PR TITLE
Use PROJECT_NAME and not CMAKE_PROJECT_NAME

### DIFF
--- a/cmake/aws-checksums-config.cmake
+++ b/cmake/aws-checksums-config.cmake
@@ -1,6 +1,6 @@
 if (BUILD_SHARED_LIBS)
-    include(${CMAKE_CURRENT_LIST_DIR}/shared/@CMAKE_PROJECT_NAME@-targets.cmake)
+    include(${CMAKE_CURRENT_LIST_DIR}/shared/@PROJECT_NAME@-targets.cmake)
 else()
-    include(${CMAKE_CURRENT_LIST_DIR}/static/@CMAKE_PROJECT_NAME@-targets.cmake)
+    include(${CMAKE_CURRENT_LIST_DIR}/static/@PROJECT_NAME@-targets.cmake)
 endif()
 


### PR DESCRIPTION
Downstream submodule consumers are broken because CMAKE_PROJECT_NAME is the consumer's project as opposed to aws-checksums.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
