### PR TITLE
Add -Werror to the neon feature test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ elseif (AWS_ARCH_ARM64)
         )
      SET_SOURCE_FILES_PROPERTIES(source/arm/crc32c_arm.c PROPERTIES COMPILE_FLAGS -march=armv8-a+crc )
 elseif ((NOT MSVC) AND AWS_ARCH_ARM32)
-    set(CMAKE_REQUIRED_FLAGS "-march=armv8-a+crc")
+    set(CMAKE_REQUIRED_FLAGS "-march=armv8-a+crc -Werror")
         check_c_source_compiles("
 #include <arm_acle.h>
 int main() {


### PR DESCRIPTION
* ensure that compiler flags that are intended to force a cortex baseline will result in a feature test failure.  This is the outcome of an internal customer ticket.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
