### PR TITLE
Fix cmake script to respect the CMAKE_INSTALL_LIBDIR / CMAKE_INSTALL_BINDIR settings for all platforms

### DIFF
--- a/cmake/AwsSharedLibSetup.cmake
+++ b/cmake/AwsSharedLibSetup.cmake
@@ -1,13 +1,21 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0.
 
-set(LIBRARY_DIRECTORY lib)
-set(RUNTIME_DIRECTORY bin)
+if(DEFINED CMAKE_INSTALL_LIBDIR)
+    set(LIBRARY_DIRECTORY ${CMAKE_INSTALL_LIBDIR})
+else()
+    set(LIBRARY_DIRECTORY lib)
+endif()
+
+if(DEFINED CMAKE_INSTALL_BINDIR)
+    set(RUNTIME_DIRECTORY ${CMAKE_INSTALL_BINDIR})
+else()
+    set(RUNTIME_DIRECTORY bin)
+endif()
+
 # Set the default lib installation path on GNU systems with GNUInstallDirs
 if (UNIX AND NOT APPLE)
     include(GNUInstallDirs)
-    set(LIBRARY_DIRECTORY ${CMAKE_INSTALL_LIBDIR})
-    set(RUNTIME_DIRECTORY ${CMAKE_INSTALL_BINDIR})
     
     # this is the absolute dumbest thing in the world, but find_package won't work without it
     # also I verified this is correctly NOT "lib64" when CMAKE_C_FLAGS includes "-m32"


### PR DESCRIPTION
*Description of changes:*
The build file was setting LIBRARY_DIRECTORY and RUNTIME_DIRECTORY to defaults, and then overwrote the defaults with the values of CMAKE_INSTALL_LIBDIR / CMAKE_INSTALL_BINDIR only for UNIX non-Apple builds, and regardless of whether or not those values were set.

This change sets the LIBRARY_DIRECTORY / RUNTIME_DIRECTORY values to use CMAKE_INSTALL_LIBDIR / CMAKE_INSTALL_BINDIR for all platforms, unless the value doesn't exist, at which point it uses the default.

NOTE: I will also submit an identical change to aws-c-common, which has the same error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
