### PR TITLE
Fix warnings in public headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: header-warnings
-  BUILDER_SOURCE: channels
+  BUILDER_VERSION: v0.9.43
+  BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-checksums
   LINUX_BASE_IMAGE: ubuntu-18-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.26
+  BUILDER_VERSION: header-warnings
+  BUILDER_SOURCE: channels
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
-  BUILDER_SOURCE: releases
   PACKAGE_NAME: aws-checksums
   LINUX_BASE_IMAGE: ubuntu-18-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}

--- a/include/aws/checksums/crc.h
+++ b/include/aws/checksums/crc.h
@@ -10,6 +10,8 @@
 
 AWS_PUSH_SANE_WARNING_LEVEL
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -33,6 +35,7 @@ AWS_CHECKSUMS_API uint32_t aws_checksums_crc32c(const uint8_t *input, int length
 #ifdef __cplusplus
 }
 #endif
+AWS_POP_SANE_WARNING_LEVEL
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_CHECKSUMS_CRC_H */

--- a/include/aws/checksums/crc.h
+++ b/include/aws/checksums/crc.h
@@ -28,7 +28,7 @@ AWS_CHECKSUMS_API uint32_t aws_checksums_crc32(const uint8_t *input, int length,
  */
 AWS_CHECKSUMS_API uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
 
-AWS_EXTERN_C_BEGIN
+AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_CHECKSUMS_CRC_H */

--- a/include/aws/checksums/crc.h
+++ b/include/aws/checksums/crc.h
@@ -10,8 +10,6 @@
 
 AWS_PUSH_SANE_WARNING_LEVEL
 
-AWS_PUSH_SANE_WARNING_LEVEL
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -35,7 +33,7 @@ AWS_CHECKSUMS_API uint32_t aws_checksums_crc32c(const uint8_t *input, int length
 #ifdef __cplusplus
 }
 #endif
-AWS_POP_SANE_WARNING_LEVEL
+
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_CHECKSUMS_CRC_H */

--- a/include/aws/checksums/crc.h
+++ b/include/aws/checksums/crc.h
@@ -8,6 +8,8 @@
 #include <aws/checksums/exports.h>
 #include <stdint.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -31,5 +33,6 @@ AWS_CHECKSUMS_API uint32_t aws_checksums_crc32c(const uint8_t *input, int length
 #ifdef __cplusplus
 }
 #endif
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_CHECKSUMS_CRC_H */

--- a/include/aws/checksums/crc.h
+++ b/include/aws/checksums/crc.h
@@ -6,13 +6,11 @@
  */
 
 #include <aws/checksums/exports.h>
+#include <aws/common/macros.h>
 #include <stdint.h>
 
 AWS_PUSH_SANE_WARNING_LEVEL
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+AWS_EXTERN_C_BEGIN
 
 /**
  * The entry point function to perform a CRC32 (Ethernet, gzip) computation.
@@ -30,10 +28,7 @@ AWS_CHECKSUMS_API uint32_t aws_checksums_crc32(const uint8_t *input, int length,
  */
 AWS_CHECKSUMS_API uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
 
-#ifdef __cplusplus
-}
-#endif
-
+AWS_EXTERN_C_BEGIN
 AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_CHECKSUMS_CRC_H */


### PR DESCRIPTION
*Description of changes:*
- Adds `AWS_PUSH_SANE_WARNING_LEVEL` and `AWS_POP_SANE_WARNING_LEVEL` to the public headers. The public header should contain at least one include; otherwise, we will receive a macro not found error. Therefore, I decided to skip adding these macros if there are no includes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.