### PR TITLE
Fix use of inline ASM labels

### DIFF
--- a/source/intel/asm/crc32c_sse42_asm.c
+++ b/source/intel/asm/crc32c_sse42_asm.c
@@ -7,6 +7,8 @@
 
 #include <aws/common/cpuid.h>
 
+/* clang-format off */
+
 /* this implementation is only for the x86_64 intel architecture */
 #if defined(__x86_64__)
 #    if defined(__clang__)
@@ -14,11 +16,12 @@
 #        pragma clang diagnostic ignored "-Wdollar-in-identifier-extension"
 #    endif
 
-#ifdef __APPLE__
-#define LABEL(label) "L_" #label "_%="
-#else
-#define LABEL(label) ".L_" #label "_%="
-#endif
+/* use local labels, so that linker doesn't think these are functions it can deadstrip */
+#    ifdef __APPLE__
+#        define LABEL(label) "L_" #label "_%="
+#    else
+#        define LABEL(label) ".L_" #label "_%="
+#    endif
 
 /*
  * Factored out common inline asm for folding crc0,crc1,crc2 stripes in rcx, r11, r10 using
@@ -373,3 +376,4 @@ uint32_t aws_checksums_crc32c_hw(const uint8_t *input, int length, uint32_t prev
 }
 
 #endif
+/* clang-format on */

--- a/source/intel/asm/crc32c_sse42_asm.c
+++ b/source/intel/asm/crc32c_sse42_asm.c
@@ -14,6 +14,12 @@
 #        pragma clang diagnostic ignored "-Wdollar-in-identifier-extension"
 #    endif
 
+#ifdef __APPLE__
+#define LABEL(label) "L_" #label "_%="
+#else
+#define LABEL(label) ".L_" #label "_%="
+#endif
+
 /*
  * Factored out common inline asm for folding crc0,crc1,crc2 stripes in rcx, r11, r10 using
  * the specified Magic Constants K1 and K2.
@@ -21,8 +27,7 @@
  * Utilizes xmm1, xmm2, xmm3, xmm4 as well as clobbering r8, r9, r11
  * Result is placed in ecx
  */
-#    define FOLD_K1K2(NAME, K1, K2)                                                                                    \
-        "fold_k1k2_" #NAME "_%=: \n"                                                                                   \
+#    define FOLD_K1K2(K1, K2)                                                                                          \
         "movl             " #K1 ", %%r8d    # Magic K1 constant \n"                                                    \
         "movl             " #K2 ", %%r9d    # Magic K2 constant \n"                                                    \
         "movq              %%rcx, %%xmm1   # crc0 into lower dword of xmm1 \n"                                         \
@@ -50,8 +55,6 @@
  */
 static inline uint32_t s_crc32c_sse42_clmul_256(const uint8_t *input, uint32_t crc) {
     __asm__ __volatile__(
-        "enter_256_%=:"
-
         "xor          %%r11, %%r11    # zero all 64 bits in r11, will track crc1 \n"
         "xor          %%r10, %%r10    # zero all 64 bits in r10, will track crc2 \n"
 
@@ -98,7 +101,7 @@ static inline uint32_t s_crc32c_sse42_clmul_256(const uint8_t *input, uint32_t c
         "crc32q   80(%[in]), %%rcx    # crc0 \n"
         "crc32q  168(%[in]), %%r11    # crc2 \n"
 
-        FOLD_K1K2(256, $0x1b3d8f29, $0x39d3b296) /* Magic Constants used to fold crc stripes into ecx */
+        FOLD_K1K2($0x1b3d8f29, $0x39d3b296) /* Magic Constants used to fold crc stripes into ecx */
 
         /* output registers
          [crc] is an input and and output so it is marked read/write (i.e. "+c")*/
@@ -121,14 +124,12 @@ static inline uint32_t s_crc32c_sse42_clmul_256(const uint8_t *input, uint32_t c
  */
 static inline uint32_t s_crc32c_sse42_clmul_1024(const uint8_t *input, uint32_t crc) {
     __asm__ __volatile__(
-        "enter_1024_%=:"
-
         "xor          %%r11, %%r11    # zero all 64 bits in r11, will track crc1 \n"
         "xor          %%r10, %%r10    # zero all 64 bits in r10, will track crc2 \n"
 
         "movl            $5, %%r8d    # Loop 5 times through 64 byte chunks in 3 parallel stripes \n"
 
-        "loop_1024_%=:"
+        LABEL(loop_1024) ": \n"
 
         "prefetcht0  128(%[in])       # \n"
         "prefetcht0  472(%[in])       # \n"
@@ -168,7 +169,7 @@ static inline uint32_t s_crc32c_sse42_clmul_1024(const uint8_t *input, uint32_t 
 
         "add            $64, %[in]    # \n"
         "sub             $1, %%r8d    # \n"
-        "jnz loop_1024_%=             # \n"
+        "jnz " LABEL(loop_1024) "     # \n"
 
         "crc32q    0(%[in]), %%rcx    # crc0 \n"
         "crc32q  344(%[in]), %%r11    # crc1 \n"
@@ -181,7 +182,7 @@ static inline uint32_t s_crc32c_sse42_clmul_1024(const uint8_t *input, uint32_t 
         "crc32q   16(%[in]), %%rcx    # crc0 \n"
         "crc32q  696(%[in]), %%r10    # crc2 \n"
 
-        FOLD_K1K2(1024, $0xe417f38a, $0x8f158014) /* Magic Constants used to fold crc stripes into ecx
+        FOLD_K1K2($0xe417f38a, $0x8f158014) /* Magic Constants used to fold crc stripes into ecx
 
                             output registers
                             [crc] is an input and and output so it is marked read/write (i.e. "+c")
@@ -205,14 +206,12 @@ static inline uint32_t s_crc32c_sse42_clmul_1024(const uint8_t *input, uint32_t 
  */
 static inline uint32_t s_crc32c_sse42_clmul_3072(const uint8_t *input, uint32_t crc) {
     __asm__ __volatile__(
-        "enter_3072_%=:"
-
         "xor          %%r11, %%r11    # zero all 64 bits in r11, will track crc1 \n"
         "xor          %%r10, %%r10    # zero all 64 bits in r10, will track crc2 \n"
 
         "movl           $16, %%r8d    # Loop 16 times through 64 byte chunks in 3 parallel stripes \n"
 
-        "loop_3072_%=:"
+        LABEL(loop_3072) ": \n"
 
         "prefetcht0  128(%[in])       # \n"
         "prefetcht0 1152(%[in])       # \n"
@@ -252,10 +251,9 @@ static inline uint32_t s_crc32c_sse42_clmul_3072(const uint8_t *input, uint32_t 
 
         "add            $64, %[in]    # \n"
         "sub             $1, %%r8d    # \n"
-        "jnz loop_3072_%=             # \n"
+        "jnz " LABEL(loop_3072) "     # \n"
 
         FOLD_K1K2(
-            3072,
             $0xa51b6135,
             $0x170076fa) /* Magic Constants used to fold crc stripes into ecx
 
@@ -297,7 +295,7 @@ uint32_t aws_checksums_crc32c_hw(const uint8_t *input, int length, uint32_t prev
     /* For small input, forget about alignment checks - simply compute the CRC32c one byte at a time */
     if (AWS_UNLIKELY(length < 8)) {
         while (length-- > 0) {
-            __asm__("loop_small_%=: CRC32B (%[in]), %[crc]" : [ crc ] "+c"(crc) : [ in ] "r"(input));
+            __asm__("CRC32B (%[in]), %[crc]" : [ crc ] "+c"(crc) : [ in ] "r"(input));
             input++;
         }
         return ~crc;
@@ -314,7 +312,7 @@ uint32_t aws_checksums_crc32c_hw(const uint8_t *input, int length, uint32_t prev
 
     /* spin through the leading unaligned input bytes (if any) one-by-one */
     while (leading-- > 0) {
-        __asm__("loop_leading_%=: CRC32B (%[in]), %[crc]" : [ crc ] "+c"(crc) : [ in ] "r"(input));
+        __asm__("CRC32B (%[in]), %[crc]" : [ crc ] "+c"(crc) : [ in ] "r"(input));
         input++;
     }
 
@@ -344,14 +342,14 @@ uint32_t aws_checksums_crc32c_hw(const uint8_t *input, int length, uint32_t prev
     /* Spin through remaining (aligned) 8-byte chunks using the CRC32Q quad word instruction */
     while (AWS_LIKELY(length >= 8)) {
         /* Hardcoding %rcx register (i.e. "+c") to allow use of qword instruction */
-        __asm__ __volatile__("loop_8_%=: CRC32Q (%[in]), %%rcx" : [ crc ] "+c"(crc) : [ in ] "r"(input));
+        __asm__ __volatile__("CRC32Q (%[in]), %%rcx" : [ crc ] "+c"(crc) : [ in ] "r"(input));
         input += 8;
         length -= 8;
     }
 
     /* Finish up with any trailing bytes using the CRC32B single byte instruction one-by-one */
     while (length-- > 0) {
-        __asm__ __volatile__("loop_trailing_%=: CRC32B (%[in]), %[crc]" : [ crc ] "+c"(crc) : [ in ] "r"(input));
+        __asm__ __volatile__("CRC32B (%[in]), %[crc]" : [ crc ] "+c"(crc) : [ in ] "r"(input));
         input++;
     }
 


### PR DESCRIPTION
These labels need to be local, otherwise they're retained in the compiled static library. At link time, some linkers (notably macOS) interpret them as new functions that can be safely stripped from the linked binary since the labels are unreferenced.

This goes wrong on macOS when you pass the `-dead_strip` linker flag, [which `rustc` does](https://github.com/rust-lang/rust/blob/a9baa16482ba4100df529ccba39c787f27ad0475/compiler/rustc_codegen_ssa/src/back/linker.rs#L552).

---

Here's an example:
```c
#include <aws/checksums/crc.h>
#include <stdlib.h>
#include <stdint.h>
#include <stdio.h>

int main(void) {
    uint8_t *buf = calloc(5000, sizeof(uint8_t));
    uint32_t checksum = aws_checksums_crc32c(buf, 5000, 0);
    printf("crc32c=%d\n", checksum);
    return 0;
}
```

```
$ clang -I target/include -c checksum.c
```

Then this works:
```
$ clang -Ltarget/lib -laws-c-common -laws-checksums checksum.o -o checksum
$ ./checksum
crc32c=-427788848
```

But this segfaults:
```
$ clang -Wl,-dead_strip -Ltarget/lib -laws-c-common -laws-checksums checksum.o -o checksum
$ ./checksum
zsh: segmentation fault  ./checksum
```

Because the CRC functions have all been stripped starting from the `enter_` label, and just fall through into whatever's next into the binary:
```
$ otool -tvV checksum | grep -A30 s_crc32c_sse42_clmul_256:
_s_crc32c_sse42_clmul_256:
0000000100003f10        pushq   %rbp
0000000100003f11        movq    %rsp, %rbp
0000000100003f14        movq    %rdi, -0x8(%rbp)
0000000100003f18        movl    %esi, -0xc(%rbp)
0000000100003f1b        movl    -0xc(%rbp), %ecx
0000000100003f1e        movq    -0x8(%rbp), %rdx
0000000100003f22        nop
0000000100003f23        nop
0000000100003f24        nop
0000000100003f25        nop
0000000100003f26        nop
0000000100003f27        nop
0000000100003f28        nop
0000000100003f29        nop
0000000100003f2a        nop
0000000100003f2b        nop
0000000100003f2c        nop
0000000100003f2d        nop
0000000100003f2e        nop
0000000100003f2f        nop
_main:
0000000100003f30        pushq   %rbp
0000000100003f31        movq    %rsp, %rbp
0000000100003f34        subq    $0x20, %rsp
0000000100003f38        movl    $0x0, -0x4(%rbp)
0000000100003f3f        movl    $0x1388, %edi                   ## imm = 0x1388
0000000100003f44        movl    $0x1, %esi
0000000100003f49        callq   0x100003f84                     ## symbol stub for: _calloc
0000000100003f4e        movq    %rax, -0x10(%rbp)
0000000100003f52        movq    -0x10(%rbp), %rdi
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
