### PR TITLE
Fix Windows clang-cl build: add /arch:AVX flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,8 @@ if (USE_CPU_EXTENSIONS)
         file(GLOB AWS_ARCH_SRC
                 "source/intel/visualc/*.c"
         )
-
+        # visualc_crc32_sse42.c uses SSE4.2 instructions. The /arch:AVX flag implicitly enables support for SSE4.2:
+        set_source_files_properties(${AWS_ARCH_SRC} PROPERTIES COMPILE_FLAGS "/arch:AVX")
         source_group("Source Files\\intel\\visualc" FILES ${AWS_ARCH_SRC})
 
     elseif(AWS_ARCH_INTEL AND AWS_HAVE_GCC_INLINE_ASM)


### PR DESCRIPTION
*Description of changes:*
Adds `/arch:AVX` flag for `visualc_crc32_sse42.c`, which requires SSE4.2 instruction support. This is required to support Visual Studio 'C++ clang tools for Windows'.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
