### PR TITLE
Refactor CPU_EXTENSIONS logic for MSVC with Clang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,13 +99,13 @@ jobs:
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }}
 
- windows-clang:
+  windows-clang:
     runs-on: windows-2022 # latest
     steps:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        python builder.pyz build -p ${{ env.PACKAGE_NAME }}
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra="-T ClangCL"
 
 
   windows-vc14:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra="-T ClangCL"
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-T ClangCL
 
 
   windows-vc14:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        python builder.pyz build -p ${{ env.PACKAGE_NAME }} -T ClangCL
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra="-T ClangCL"
 
 
   windows-vc14:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-T ClangCL
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-T,ClangCL
 
 
   windows-vc14:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,15 +99,6 @@ jobs:
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }}
 
-  windows-clang:
-    runs-on: windows-2022 # latest
-    steps:
-    - name: Build ${{ env.PACKAGE_NAME }} + consumers
-      run: |
-        python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-T --cmake-extra=ClangCL
-
-
   windows-vc14:
     runs-on: windows-2019 # windows-2019 is last env with Visual Studio 2015 (v14.0)
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-T ClangCL
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} -T ClangCL
 
 
   windows-vc14:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-T,ClangCL
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-TClangCL
 
 
   windows-vc14:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra="-T ClangCL"
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }}
 
 
   windows-vc14:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,15 @@ jobs:
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }}
 
+ windows-clang:
+    runs-on: windows-2022 # latest
+    steps:
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-T ClangCL
+
+
   windows-vc14:
     runs-on: windows-2019 # windows-2019 is last env with Visual Studio 2015 (v14.0)
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-TClangCL
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-T --cmake-extra=ClangCL
 
 
   windows-vc14:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,16 +58,18 @@ file(GLOB AWS_ARCH_SRC
         )
 
 if (USE_CPU_EXTENSIONS)
-    # First, check if inline assembly is available. Inline assembly can also be supported by MSVC if the compiler in use is Clang.
-    if(AWS_ARCH_INTEL AND AWS_HAVE_GCC_INLINE_ASM)
-        file(GLOB AWS_ARCH_SRC
-                "source/intel/asm/*.c"
+    if(AWS_ARCH_INTEL)
+        # First, check if inline assembly is available. Inline assembly can also be supported by MSVC if the compiler in use is Clang.
+        if(AWS_HAVE_GCC_INLINE_ASM)
+            file(GLOB AWS_ARCH_SRC
+                    "source/intel/asm/*.c"
+                )
+        elseif (MSVC)
+            file(GLOB AWS_ARCH_SRC
+                    "source/intel/visualc/*.c"
             )
-    elseif (MSVC AND AWS_ARCH_INTEL)
-        file(GLOB AWS_ARCH_SRC
-                "source/intel/visualc/*.c"
-        )
-        source_group("Source Files\\intel\\visualc" FILES ${AWS_ARCH_SRC})
+            source_group("Source Files\\intel\\visualc" FILES ${AWS_ARCH_SRC})
+        endif()
     endif()
 
     if (MSVC AND AWS_ARCH_ARM64)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,17 +58,16 @@ file(GLOB AWS_ARCH_SRC
         )
 
 if (USE_CPU_EXTENSIONS)
-    if (MSVC AND AWS_ARCH_INTEL)
-        file(GLOB AWS_ARCH_SRC
-                "source/intel/visualc/*.c"
-        )
-
-        source_group("Source Files\\intel\\visualc" FILES ${AWS_ARCH_SRC})
-
-    elseif(AWS_ARCH_INTEL AND AWS_HAVE_GCC_INLINE_ASM)
+    # First, check if inline assembly is available. Inline assembly can also be supported by MSVC if the compiler in use is Clang.
+    if(AWS_ARCH_INTEL AND AWS_HAVE_GCC_INLINE_ASM)
         file(GLOB AWS_ARCH_SRC
                 "source/intel/asm/*.c"
             )
+    elseif (MSVC AND AWS_ARCH_INTEL)
+        file(GLOB AWS_ARCH_SRC
+                "source/intel/visualc/*.c"
+        )
+        source_group("Source Files\\intel\\visualc" FILES ${AWS_ARCH_SRC})
     endif()
 
     if (MSVC AND AWS_ARCH_ARM64)


### PR DESCRIPTION
*Description of changes:*
`visualc_crc32c_sse42.c` fails to compile on MSVC with Clang because we don't compile it with the AVX or AVX2 flag. Since inline assembly is supported by Clang even on MSVC, first check if we can use that. This will fix the https://github.com/awslabs/aws-checksums/pull/66.

TODO: fix warnings and add CI for MSVC with Clang.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
