### PR TITLE
Remove unused source/arm/asm directory include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,6 @@ if (USE_CPU_EXTENSIONS)
         if (AWS_ARM32_CRC)
             file(GLOB AWS_ARCH_SRC
                 "source/arm/*.c"
-                "source/arm/asm/*.c"
                 )
             SET_SOURCE_FILES_PROPERTIES(source/arm/crc32c_arm.c PROPERTIES COMPILE_FLAGS -march=armv8-a+crc )
         endif()


### PR DESCRIPTION
*Description of changes:*
- There is no `source/arm/asm` directory. Remove it from CMake.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
