### PR TITLE
Add missing extern c to new header

### DIFF
--- a/include/aws/checksums/checksums.h
+++ b/include/aws/checksums/checksums.h
@@ -1,14 +1,17 @@
 #ifndef AWS_CHECKSUMS_CHECKSUMS_H
 #define AWS_CHECKSUMS_CHECKSUMS_H
-
-#include <aws/common/common.h>
-
-#include <aws/checksums/exports.h>
-
 /**
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+
+
+#include <aws/common/common.h>
+#include <aws/checksums/exports.h>
+
+
+AWS_PUSH_SANE_WARNING_LEVEL
+AWS_EXTERN_C_BEGIN
 
 /**
  * Initializes internal data structures used by aws-checksums.
@@ -22,5 +25,8 @@ AWS_CHECKSUMS_API void aws_checksums_library_init(struct aws_allocator *allocato
  * Shuts down the internal data structures used by aws-checksums.
  */
 AWS_CHECKSUMS_API void aws_checksums_library_clean_up(void);
+
+AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_CHECKSUMS_CHECKSUMS_H */

--- a/include/aws/checksums/checksums.h
+++ b/include/aws/checksums/checksums.h
@@ -5,10 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-
-#include <aws/common/common.h>
 #include <aws/checksums/exports.h>
-
+#include <aws/common/common.h>
 
 AWS_PUSH_SANE_WARNING_LEVEL
 AWS_EXTERN_C_BEGIN


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
extern c is missing on the new header and cpp compilers will happily mangle function names and break builds. add the missing extern c

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
