### PR TITLE
Fix clang-cl compilation

### DIFF
--- a/source/xxhash.c
+++ b/source/xxhash.c
@@ -46,9 +46,6 @@
 #        elif defined(__clang__) && defined(_MSC_VER) /* clang-cl.exe */
 #            include <emmintrin.h>                    /* SSE2 */
 #            if XXH_DISPATCH_AVX2 || XXH_DISPATCH_AVX512
-#                include <avx2intrin.h>
-#                include <avx512fintrin.h>
-#                include <avxintrin.h>
 #                include <immintrin.h> /* AVX2, AVX512F */
 #                include <smmintrin.h>
 #            endif


### PR DESCRIPTION
Fix the following error:

```
#error "Never use <avx2intrin.h> directly; include <immintrin.h> instead."
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
