### PR TITLE
Update deprecated OpenBSD CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.76
+  BUILDER_VERSION: v0.9.96
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-checksums
@@ -300,7 +300,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       id: test
-      uses: cross-platform-actions/action@v0.25.0
+      uses: cross-platform-actions/action@v1.3.0
       with:
         #note: sanitizer seems to be broken on s390x (fails trying to allocate several tbs of mem) and package manager works slightly differently that on regular ubuntu
         operating_system: freebsd
@@ -348,7 +348,7 @@ jobs:
       fail-fast: false
       matrix:
         # OpenBSD only supports the two most recent releases
-        version: ['7.4', '7.5']
+        version: ['7.8', '7.9']
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -359,7 +359,7 @@ jobs:
       with:
         submodules: true
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
-      uses: cross-platform-actions/action@v0.25.0
+      uses: cross-platform-actions/action@v1.3.0
       with:
         operating_system: openbsd
         architecture: x86-64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,7 @@ jobs:
         shell: bash
         environment_variables: AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION AWS_REGION
         run: |
-          sudo pkg_add awscli py3-pip py3-urllib3
+          sudo pkg_add awscli%v2 py3-pip py3-urllib3
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz', 'builder')"
           chmod a+x builder
           ./builder build -p ${{ env.PACKAGE_NAME }}


### PR DESCRIPTION
*Issue #, if available:*
OpenBSD 7.4 and 7.5 are deprecated, 7.4 packages were removed from mirrors.

*Description of changes:*
- Bump OpenBSD versions to 7.8 and 7.9 (the currently supported versions)
- Update cross-platform-actions/action to v1.3.0 (both OpenBSD and FreeBSD jobs)
- Bump aws-crt-builder to v0.9.96

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
