### PR TITLE
CMake: Fix missing find_dependency

### DIFF
--- a/cmake/aws-checksums-config.cmake
+++ b/cmake/aws-checksums-config.cmake
@@ -1,3 +1,8 @@
+include(CMakeFindDependencyMacro)
+if(NOT @IN_SOURCE_BUILD@)
+    find_dependency(aws-c-common)
+endif()
+
 macro(aws_load_targets type)
     include(${CMAKE_CURRENT_LIST_DIR}/${type}/@PROJECT_NAME@-targets.cmake)
 endmacro()


### PR DESCRIPTION
In reviewing https://github.com/microsoft/vcpkg/pull/53539 , GPT 5.6 Sol reports:

>- **The generated CMake usage does not configure.** `AWS::aws-checksums` exposes `AWS::aws-c-common` in its link interface, but [`cmake/aws-checksums-config.cmake`](https://github.com/awslabs/aws-checksums/blob/32fed6fc25a90146bd0ac7e5c639e3778b78fdf1/cmake/aws-checksums-config.cmake) does not load that dependency before importing the target. Consequently, the generated `find_package(aws-checksums CONFIG REQUIRED)` usage fails in both Release and Debug. This conflicts with the requirement that generated usage be accurate ([`.github/skills/shared/review-vcpkg-pr-guide.md`](https://github.com/microsoft/vcpkg/blob/127402f1c75bb3d5ff6bce04b285faa4930a5aca/.github/skills/shared/review-vcpkg-pr-guide.md#L52-L53)). The defect also exists in 0.2.10.

See corresponding part in CMakeLists.txt:

https://github.com/awslabs/aws-checksums/blob/7ae826b37b625bb182eecc61196ce63026dab901/CMakeLists.txt#L7-L10


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
